### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/core_js/tools.js
+++ b/core_js/tools.js
@@ -288,7 +288,7 @@ function decodeURL(url) {
     }
 
     // Required (e.g., to fix https://github.com/ClearURLs/Addon/issues/71)
-    if(rtn.substr(0, 4) !== 'http') {
+    if(!rtn.startsWith('http')) {
         rtn = 'http://'+rtn
     }
 

--- a/external_js/ip-range-check.js
+++ b/external_js/ip-range-check.js
@@ -484,10 +484,10 @@ function check_single_cidr(addr, cidr) {
     while ((lastColon = string.indexOf(':', lastColon + 1)) >= 0) {
       colonCount++;
     }
-    if (string.substr(0, 2) === '::') {
+    if (string.startsWith('::')) {
       colonCount--;
     }
-    if (string.substr(-2, 2) === '::') {
+    if (string.endsWith('::')) {
       colonCount--;
     }
     if (colonCount > parts) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.startsWith()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) or [String.prototype.endsWith()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith) which aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.