### PR TITLE
Add support for custom rules

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -167,6 +167,10 @@
         "message": "The url to the data.json file (rules)",
         "description": "This string is used as name for the rule url label."
     },
+    "setting_custom_rules_label": {
+        "message": "Custom rules",
+        "description": "This string is used as name for the custom rules label."
+    },
     "settings_html_save_button": {
         "message": "Save & reload addon",
         "description": "This string is used as name for the save&reload button on the settings page."

--- a/clearurls.js
+++ b/clearurls.js
@@ -182,51 +182,51 @@ function start() {
      * Initialize the providers form the JSON object.
      *
      */
-    function createProviders() {
-        let data = storage.ClearURLsData;
-
+    function createProviders(data) {
         for (let p = 0; p < prvKeys.length; p++) {
-            //Create new provider
-            providers.push(new Provider(prvKeys[p], data.providers[prvKeys[p]].getOrDefault('completeProvider', false),
-                data.providers[prvKeys[p]].getOrDefault('forceRedirection', false)));
+            if (prvKeys[p] in data.providers) {
+                //Create new provider
+                providers.push(new Provider(prvKeys[p], data.providers[prvKeys[p]].getOrDefault('completeProvider', false),
+                    data.providers[prvKeys[p]].getOrDefault('forceRedirection', false)));
 
-            //Add URL Pattern
-            providers[p].setURLPattern(data.providers[prvKeys[p]].getOrDefault('urlPattern', ''));
+                //Add URL Pattern
+                providers[p].setURLPattern(data.providers[prvKeys[p]].getOrDefault('urlPattern', ''));
 
-            let rules = data.providers[prvKeys[p]].getOrDefault('rules', []);
-            //Add rules to provider
-            for (let r = 0; r < rules.length; r++) {
-                providers[p].addRule(rules[r]);
-            }
+                let rules = data.providers[prvKeys[p]].getOrDefault('rules', []);
+                //Add rules to provider
+                for (let r = 0; r < rules.length; r++) {
+                    providers[p].addRule(rules[r]);
+                }
 
-            let rawRules = data.providers[prvKeys[p]].getOrDefault('rawRules', []);
-            //Add raw rules to provider
-            for (let raw = 0; raw < rawRules.length; raw++) {
-                providers[p].addRawRule(rawRules[raw]);
-            }
+                let rawRules = data.providers[prvKeys[p]].getOrDefault('rawRules', []);
+                //Add raw rules to provider
+                for (let raw = 0; raw < rawRules.length; raw++) {
+                    providers[p].addRawRule(rawRules[raw]);
+                }
 
-            let referralMarketingRules = data.providers[prvKeys[p]].getOrDefault('referralMarketing', []);
-            //Add referral marketing rules to provider
-            for (let referralMarketing = 0; referralMarketing < referralMarketingRules.length; referralMarketing++) {
-                providers[p].addReferralMarketing(referralMarketingRules[referralMarketing]);
-            }
+                let referralMarketingRules = data.providers[prvKeys[p]].getOrDefault('referralMarketing', []);
+                //Add referral marketing rules to provider
+                for (let referralMarketing = 0; referralMarketing < referralMarketingRules.length; referralMarketing++) {
+                    providers[p].addReferralMarketing(referralMarketingRules[referralMarketing]);
+                }
 
-            let exceptions = data.providers[prvKeys[p]].getOrDefault('exceptions', []);
-            //Add exceptions to provider
-            for (let e = 0; e < exceptions.length; e++) {
-                providers[p].addException(exceptions[e]);
-            }
+                let exceptions = data.providers[prvKeys[p]].getOrDefault('exceptions', []);
+                //Add exceptions to provider
+                for (let e = 0; e < exceptions.length; e++) {
+                    providers[p].addException(exceptions[e]);
+                }
 
-            let redirections = data.providers[prvKeys[p]].getOrDefault('redirections', []);
-            //Add redirections to provider
-            for (let re = 0; re < redirections.length; re++) {
-                providers[p].addRedirection(redirections[re]);
-            }
+                let redirections = data.providers[prvKeys[p]].getOrDefault('redirections', []);
+                //Add redirections to provider
+                for (let re = 0; re < redirections.length; re++) {
+                    providers[p].addRedirection(redirections[re]);
+                }
 
-            let methods = data.providers[prvKeys[p]].getOrDefault('methods', []);
-            //Add HTTP methods list to provider
-            for (let re = 0; re < methods.length; re++) {
-                providers[p].addMethod(methods[re]);
+                let methods = data.providers[prvKeys[p]].getOrDefault('methods', []);
+                //Add HTTP methods list to provider
+                for (let re = 0; re < methods.length; re++) {
+                    providers[p].addMethod(methods[re]);
+                }
             }
         }
     }
@@ -239,7 +239,12 @@ function start() {
      */
     function toObject(retrievedText) {
         getKeys(storage.ClearURLsData.providers);
-        createProviders();
+        createProviders(storage.ClearURLsData);
+
+        if("providers" in storage.customRules) {
+            getKeys(storage.customRules.providers);
+            createProviders(storage.customRules);
+        }
     }
 
     /**

--- a/clearurls.js
+++ b/clearurls.js
@@ -173,7 +173,7 @@ function start() {
      * @param {object} obj
      */
     function getKeys(obj) {
-        for (const key in obj) {
+        for (const key of Object.keys(obj)) {
             prvKeys.push(key);
         }
     }

--- a/core_js/settings.js
+++ b/core_js/settings.js
@@ -82,6 +82,10 @@ function save() {
     saveData("badged_color", pickr.getColor().toHEXA().toString())
         .then(() => saveData("ruleURL", document.querySelector('input[name=ruleURL]').value))
         .then(() => saveData("hashURL", document.querySelector('input[name=hashURL]').value))
+        .then(() => saveData(
+            "customRules",
+            document.querySelector('textarea[name=customRules]').value
+        ), handleError)
         .then(() => saveData("types", document.querySelector('input[name=types]').value))
         .then(() => saveData("logLimit", Math.max(0, Math.min(5000, document.querySelector('input[name=logLimit]').value))))
         .then(() => browser.runtime.sendMessage({
@@ -122,6 +126,7 @@ function getData() {
 
     loadData("ruleURL")
         .then(() => loadData("hashURL"))
+        .then(() => loadData("customRules"))
         .then(() => loadData("types"))
         .then(() => loadData("logLimit"))
         .then(logData => {
@@ -163,10 +168,16 @@ async function loadData(name) {
             params: [name]
         }).then(data => {
             settings[name] = data.response;
-            if (document.querySelector('input[id=' + name + ']') == null) {
+            if (document.querySelector('*[id=' + name + ']') == null) {
                 console.debug(name)
             }
-            document.querySelector('input[id=' + name + ']').value = data.response;
+            switch (name) {
+                case "customRules":
+                    document.querySelector('*[id=' + name + ']').value = JSON.stringify(data.response);
+                    break;
+                default:
+                    document.querySelector('*[id=' + name + ']').value = data.response;
+            }
             resolve(data);
         }, handleError);
     });
@@ -202,6 +213,7 @@ function setText() {
     document.getElementById('reset_settings_btn').setAttribute('title', translate('setting_html_reset_button_title'));
     document.getElementById('rule_url_label').textContent = translate('setting_rule_url_label');
     document.getElementById('hash_url_label').textContent = translate('setting_hash_url_label');
+    document.getElementById('custom_rules_label').textContent = translate('setting_custom_rules_label');
     document.getElementById('types_label').innerHTML = translate('setting_types_label');
     document.getElementById('save_settings_btn').textContent = translate('settings_html_save_button');
     document.getElementById('save_settings_btn').setAttribute('title', translate('settings_html_save_button_title'));

--- a/core_js/storage.js
+++ b/core_js/storage.js
@@ -55,6 +55,7 @@ function storageDataAsString(key) {
     switch (key) {
         case "ClearURLsData":
         case "log":
+        case "customRules":
             return JSON.stringify(value);
         case "types":
             return value.toString();
@@ -152,6 +153,7 @@ function getEntireData() {
  */
 function setData(key, value) {
     switch (key) {
+        case "customRules":
         case "ClearURLsData":
         case "log":
             storage[key] = JSON.parse(value);
@@ -216,6 +218,7 @@ function initSettings() {
     storage.badged_color = "#ffa500";
     storage.hashURL = "https://rules2.clearurls.xyz/rules.minify.hash";
     storage.ruleURL = "https://rules2.clearurls.xyz/data.minify.json";
+    storage.customRules = {};
     storage.contextMenuEnabled = true;
     storage.historyListenerEnabled = true;
     storage.localHostsSkipping = true;

--- a/html/settings.html
+++ b/html/settings.html
@@ -106,6 +106,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </p>
                 <br />
                 <p>
+                    <label id="custom_rules_label"></label><br />
+                    <textarea id="customRules" name="customRules" class="form-control"></textarea>
+                </p>
+                <br />
+                <p>
                     <label id="types_label"></label><br />
                     <input type="text" id="types" value="" name="types" class="form-control" />
                 </p>


### PR DESCRIPTION
This adds a textarea in the settings page that can be used to enter custom rules in the same format as data.json. These rules are applied on top of the ones from data.json.