### PR TITLE
Fixes #196

### DIFF
--- a/core_js/historyListener.js
+++ b/core_js/historyListener.js
@@ -44,7 +44,7 @@ function historyCleaner(details) {
         if(urlBefore !== urlAfter) {
             browser.tabs.executeScript(details.tabId, {
                 frameId: details.frameId,
-                   code: 'history.replaceState({state: "cleaned_history"},"",'+JSON.stringify(urlAfter)+');'
+                   code: 'history.replaceState({state: null},"",'+JSON.stringify(urlAfter)+');'
             }).then(() => {}, onError);
         }
     }


### PR DESCRIPTION
Very simple fix for #196 that has been discussed in that issue.

It doesn't break apps as much, and it actually prevents some form of fingerprinting (users of this add-on are probably the only ones to have the string "cleaned_history" in their history stack).