### PR TITLE
Add Whitelist

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -87,6 +87,10 @@
         "message": "Show numbers of cleaned urls",
         "description": "This string is used as title for the badges switch button on the popup page."
     },
+    "popup_html_configs_whitelist_button": {
+        "message": "Whitelist Site",
+        "description": "This string is used as name for the whitelist button on the popup page."
+    },
     "popup_html_statistics_head": {
         "message": "Statistics",
         "description": "This string is used as title for the statistics on the popup page."

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -87,8 +87,12 @@
         "message": "Show numbers of cleaned urls",
         "description": "This string is used as title for the badges switch button on the popup page."
     },
-    "popup_html_configs_whitelist_button": {
+    "popup_html_configs_whitelist_button_add": {
         "message": "Whitelist Site",
+        "description": "This string is used as name for the whitelist button on the popup page."
+    },
+    "popup_html_configs_whitelist_button_remove": {
+        "message": "Remove from Whitelist",
         "description": "This string is used as name for the whitelist button on the popup page."
     },
     "popup_html_statistics_head": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -183,6 +183,10 @@
         "message": "The url to the rules.hash file (hash)",
         "description": "This string is used as name for the rule.hash url label."
     },
+    "setting_whitelist_list_label": {
+        "message": "Whitelisted sites",
+        "description": "This string is used as name for the whitelisted sites list label."
+    },
     "setting_types_label": {
         "message": "<a href='https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType' target='_blank'>Request types</a> (expert level)",
         "description": "This string is used as name for the types label."

--- a/clearurls.js
+++ b/clearurls.js
@@ -47,6 +47,19 @@ function removeFieldsFormURL(provider, pureUrl, quiet = false, request = null) {
     let rawRules = provider.getRawRules();
     let urlObject = new URL(url);
 
+    /*
+    * Skip whitelisted sites
+    */
+    for (const site of storage.whitelist) {
+        if (url.indexOf(site) != -1) {
+            return {
+                "changes": false,
+                "url": url,
+                "cancel": false
+            }
+        }
+    }
+
     if (storage.localHostsSkipping && checkLocalURL(urlObject)) {
         return {
             "changes": false,

--- a/core_js/popup.js
+++ b/core_js/popup.js
@@ -156,6 +156,29 @@ function setSwitchButton(id, varname)
 }
 
 /**
+* Adds the site the user is on to the whitelist
+* Whitelisted sites do not get filtered
+* @param {string} site Site url to add to whitelist
+*/
+function addToWhitelist() {
+    let site;
+    browser.tabs.query({active: true, currentWindow: true}, function(tabs) { // Couldn't figure out how to access currentUrl var
+        site = tabs[0].url;                                                  // So this is used instead
+    });
+    browser.runtime.sendMessage({
+        function: "getData",
+        params: ['whitelist']
+    }).then((data) => {
+        let domain = site.replace(/.*?:(?:\/\/)?(.*?\/).*/, '$1')
+        data.response.push(domain)
+        browser.runtime.sendMessage({
+            function: "setData",
+            params: ['whitelist', data.response]
+        }).catch(handleError);
+    }).catch(handleError);
+}
+
+/**
 * Reset the global statistic
 */
 function resetGlobalCounter(){
@@ -191,6 +214,7 @@ function resetGlobalCounter(){
         .then(() => loadData("getCurrentURL", "currentURL"))
         .then(() => {
             init();
+            document.getElementById('whitelist_btn').onclick = addToWhitelist;
             document.getElementById('reset_counter_btn').onclick = resetGlobalCounter;
             changeSwitchButton("globalStatus", "globalStatus");
             changeSwitchButton("tabcounter", "badgedStatus");
@@ -220,6 +244,7 @@ function setText()
     injectText('configs_switch_filter','popup_html_configs_switch_filter');
     injectText('configs_head','popup_html_configs_head');
     injectText('configs_switch_statistics','configs_switch_statistics');
+    injectText('whitelist_btn','popup_html_configs_whitelist_button');
     document.getElementById('donate').title = translate('donate_button');
 }
 

--- a/core_js/popup.js
+++ b/core_js/popup.js
@@ -168,7 +168,8 @@ function addToWhitelist() {
         function: "getData",
         params: ['whitelist']
     }).then((data) => {
-        let domain = site.replace(/.*?:(?:\/\/)?(.*?\/).*/, '$1')
+        let siteUrl = new URL(site)
+        let domain = siteUrl.hostname
         data.response.push(domain)
         browser.runtime.sendMessage({
             function: "setData",

--- a/core_js/popup.js
+++ b/core_js/popup.js
@@ -158,7 +158,6 @@ function setSwitchButton(id, varname)
 /**
 * Adds the site the user is on to the whitelist
 * Whitelisted sites do not get filtered
-* @param {string} site Site url to add to whitelist
 */
 function addToWhitelist() {
     let site;

--- a/core_js/settings.js
+++ b/core_js/settings.js
@@ -82,6 +82,7 @@ function save() {
     saveData("badged_color", pickr.getColor().toHEXA().toString())
         .then(() => saveData("ruleURL", document.querySelector('input[name=ruleURL]').value))
         .then(() => saveData("hashURL", document.querySelector('input[name=hashURL]').value))
+        .then(() => saveData("whitelist", document.querySelector('input[name=whitelist]').value))
         .then(() => saveData("types", document.querySelector('input[name=types]').value))
         .then(() => saveData("logLimit", Math.max(0, Math.min(5000, document.querySelector('input[name=logLimit]').value))))
         .then(() => browser.runtime.sendMessage({
@@ -122,6 +123,7 @@ function getData() {
 
     loadData("ruleURL")
         .then(() => loadData("hashURL"))
+        .then(() => loadData("whitelist"))
         .then(() => loadData("types"))
         .then(() => loadData("logLimit"))
         .then(logData => {
@@ -216,6 +218,7 @@ function setText() {
     document.getElementById('reset_settings_btn').setAttribute('title', translate('setting_html_reset_button_title'));
     document.getElementById('rule_url_label').textContent = translate('setting_rule_url_label');
     document.getElementById('hash_url_label').textContent = translate('setting_hash_url_label');
+    document.getElementById('whitelist_list_label').textContent = translate('setting_whitelist_list_label');
     document.getElementById('types_label').innerHTML = translate('setting_types_label');
     document.getElementById('save_settings_btn').textContent = translate('settings_html_save_button');
     document.getElementById('save_settings_btn').setAttribute('title', translate('settings_html_save_button_title'));

--- a/core_js/settings.js
+++ b/core_js/settings.js
@@ -82,7 +82,7 @@ function save() {
     saveData("badged_color", pickr.getColor().toHEXA().toString())
         .then(() => saveData("ruleURL", document.querySelector('input[name=ruleURL]').value))
         .then(() => saveData("hashURL", document.querySelector('input[name=hashURL]').value))
-        .then(() => saveData("whitelist", document.querySelector('input[name=whitelist]').value))
+        .then(() => saveData("whitelist", document.querySelector('input[name=whitelist]').value.split(',')))
         .then(() => saveData("types", document.querySelector('input[name=types]').value))
         .then(() => saveData("logLimit", Math.max(0, Math.min(5000, document.querySelector('input[name=logLimit]').value))))
         .then(() => browser.runtime.sendMessage({

--- a/core_js/storage.js
+++ b/core_js/storage.js
@@ -216,6 +216,7 @@ function initSettings() {
     storage.badged_color = "#ffa500";
     storage.hashURL = "https://rules2.clearurls.xyz/rules.minify.hash";
     storage.ruleURL = "https://rules2.clearurls.xyz/data.minify.json";
+    storage.whitelist = []; // TODO: If we do whitelist per rule, this needs to be obj
     storage.contextMenuEnabled = true;
     storage.historyListenerEnabled = true;
     storage.localHostsSkipping = true;

--- a/html/popup.html
+++ b/html/popup.html
@@ -87,6 +87,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     </label>
                     <div class="clearfix"></div>
                     <br />
+                    <button type="button" id="whitelist_btn" class="btn btn-primary btn-sm text-wrap"></button>
                 </div>
             </div>
 

--- a/html/popup.html
+++ b/html/popup.html
@@ -86,8 +86,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         <label id="configs_switch_statistics"></label>
                     </label>
                     <div class="clearfix"></div>
+                    <div class="text-center">
+                        <button type="button" id="whitelist_btn" class="btn btn-primary btn-sm text-wrap"></button>
+                    </div>
                     <br />
-                    <button type="button" id="whitelist_btn" class="btn btn-primary btn-sm text-wrap"></button>
                 </div>
             </div>
 

--- a/html/settings.html
+++ b/html/settings.html
@@ -106,6 +106,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </p>
                 <br />
                 <p>
+                    <label id="whitelist_list_label"></label><br />
+                    <input type="text" id="whitelist" value="" name="whitelist" class="form-control" />
+                </p>
+                <br />
+                <p>
                     <label id="types_label"></label><br />
                     <input type="text" id="types" value="" name="types" class="form-control" />
                 </p>


### PR DESCRIPTION
This PR adds a whitelist button, which then allows users to prevent sites from being filtered
Whitelisting is now pretty much finished, only the issue with subdomains being treated like separate sites remain, just waiting on maintainer's opinions on adding another library. (If current behaviour is also like there could be an option in settings)
*This PR has only been tested on firefox, if chrome users could test it be greatly appreciated*

- [ ] Make whitelist for full domain (currently if `www.example.com` is whitelisted, `example.com` isn't. This could be considered intentional, but it would still break cases like `www.example.com` calling `assets.example.com`)
- [x] Allow users to unwhitelist whitelisted sites (only possible via full reset atm, would replace `Whitelist Site` with `Remove From Whitelist` when viewing a whitelisted page)
- - [x] Update button after user presses it
- - [x] Make button spam resistant 
- [x] List whitelisted sites in settings
- [x] Fix styling
- [x] Support for ip addresses? (Might already be working, untested)
- [ ] Whitelist sites on per rule basis (meaning exempt a site from one rule but not another, requested in #93, but might not be added in this PR)

Once done this will close #93  and its many duplicates

![image](https://github.com/ClearURLs/Addon/assets/83927639/6bdfa41e-1be7-4e00-9060-9d29b7bc336e)
 