### PR TITLE
fix(tools): encode search uri params

### DIFF
--- a/core_js/tools.js
+++ b/core_js/tools.js
@@ -347,7 +347,7 @@ function urlSearchParamsToString(searchParams) {
 
     searchParams.forEach((value, key) => {
         if (value) {
-            rtn.push(key + '=' + value)
+            rtn.push(key + '=' + encodeURIComponent(value))
         } else {
             rtn.push(key)
         }


### PR DESCRIPTION
fixes #407
fixes #409
fixes #413
fixes #414
fixes #421
fixes #424

might fix: https://github.com/ClearURLs/Addon/issues/405 (I'm on MS Edge and searching something with spaces on DuckDuckGo with the latest ClearURLs enabled significantly slows my browser down. This doesn't happen with my changes)