### PR TITLE
Added URLCheck to 'projects that use...' in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Please push your translation into the folder `_locales/{language code}/messages.
 * [Unalix-nim](https://github.com/AmanoTeam/Unalix-nim) small, dependency-free, fast Nim package and CLI tool for removing tracking fields from URLs
 * [UnalixAndroid](https://github.com/AmanoTeam/UnalixAndroid) simple Android app that removes link masking/tracking and optionally resolves shortened links
 * [pl-fe](https://github.com/mkljczk/pl-fe) is a Fediverse client which uses ClearURLs code to clean URLs from displayed posts and recommend cleaning URLs from created posts
+* [URLCheck](https://github.com/TrianguloY/URLCheck) is an Android app to review and edit URLs before opening them. Allows to use the ClearURLs catalog.
 
 ## Recommended by...
 *  [ghacks-user.js](https://github.com/ghacksuserjs/ghacks-user.js/wiki/4.1-Extensions)


### PR DESCRIPTION
I'm the author of [URLCheck](https://github.com/TrianguloY/URLCheck), and Android app that uses ClearURLs catalog. I found that the 'Projects that use parts of ClearURLs' of the readme was updated recently, which reminded me of adding my own app there.

Note: if there is anything else I need to change/edit, or if this addition was not desired, just say so and I'll do whatever is necessary.

Thank you for your time.