### PR TITLE
fix(#510): fix fragment parsing for padded hash values

### DIFF
--- a/core_js/utils/URLHashParams.js
+++ b/core_js/utils/URLHashParams.js
@@ -32,14 +32,13 @@ class URLHashParams {
         const hash = url.hash.slice(1);
         const params = hash.split('&');
         for (const p of params) {
-            const param = p.split('=');
-            if (!param[0])
+            if (!p)
                 continue;
-            const key = param[0];
-            let value = null;
-            if (param.length === 2 && param[1]) {
-                value = param[1];
-            }
+            const separator = p.indexOf('=');
+            const key = separator === -1 ? p : p.slice(0, separator);
+            if (!key)
+                continue;
+            const value = separator === -1 ? null : p.slice(separator + 1);
             this._params.put(key, value);
         }
     }
@@ -51,7 +50,7 @@ class URLHashParams {
     }
     get(name) {
         const [first] = this._params.get(name);
-        if (first) {
+        if (first !== undefined) {
             return first;
         }
         return null;
@@ -65,7 +64,7 @@ class URLHashParams {
     toString() {
         const rtn = [];
         this._params.forEach((key, value) => {
-            if (value) {
+            if (value !== null) {
                 rtn.push(key + '=' + value);
             }
             else {

--- a/core_js/utils/URLHashParams.js
+++ b/core_js/utils/URLHashParams.js
@@ -64,11 +64,11 @@ class URLHashParams {
     toString() {
         const rtn = [];
         this._params.forEach((key, value) => {
-            if (value !== null) {
-                rtn.push(key + '=' + value);
+            if (value === null) {
+                rtn.push(key);
             }
             else {
-                rtn.push(key);
+                rtn.push(key + '=' + value);
             }
         });
         return rtn.join('&');


### PR DESCRIPTION
## Summary

  Fix fragment parsing so ClearURLs preserves legal fragment payloads containing `=` padding, including cases like `#token=` and `#token==`.

  This addresses the Claude login issue where magic-link URLs were being rewritten in a lossy way, causing the fragment token to break.

  ## Problem

  ClearURLs parses fragment content through `URLHashParams`, but the current implementation reconstructs fragment values incorrectly when they
  contain trailing `=` or additional `=` characters.

  Examples of broken cases before this change:
  - `#token=` became `#token`
  - `#token==` became `#token`
  - `#state=abc==` became `#state=abc`

  That behavior is not valid for arbitrary URI fragments and can break sites that store opaque state in the hash.

  ## Changes

  - parse fragment entries by splitting only on the first `=`
  - preserve everything after the first `=` verbatim
  - preserve empty fragment values instead of collapsing them
  - update serialization so `""` and `null` are handled distinctly

  ## Result

  The following fragments now round-trip correctly:
  - `#token=`
  - `#token==`
  - `#state=abc==`
  - `#foo=bar=baz`
  - `#plain`

  ## Scope

  This PR is intentionally limited to the fragment-preservation bugfix.

  The broader “disable on this site/domain” functionality will be handled separately as a feature PR.

## Related Issues
* Implements #510 