### PR TITLE
fix(#509): add disable on current site control

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -123,6 +123,38 @@
         "message": "Open the log",
         "description": "This string is used as title for the log button on the popup page."
     },
+    "popup_html_site_head": {
+        "message": "Site",
+        "description": "This string is used as title for the current site section on the popup page."
+    },
+    "popup_html_site_disable": {
+        "message": "Disable on this site",
+        "description": "This string is used as label for disabling ClearURLs on the current site."
+    },
+    "popup_html_site_disable_title": {
+        "message": "Disable ClearURLs on the current site",
+        "description": "This string is used as title for the current-site disable button."
+    },
+    "popup_html_site_enable": {
+        "message": "Enable on this site",
+        "description": "This string is used as label for enabling ClearURLs on the current site."
+    },
+    "popup_html_site_enable_title": {
+        "message": "Enable ClearURLs again on the current site",
+        "description": "This string is used as title for the current-site enable button."
+    },
+    "popup_html_site_enabled": {
+        "message": "ClearURLs is active on $1",
+        "description": "This string is used to show that ClearURLs is active on the current site."
+    },
+    "popup_html_site_disabled": {
+        "message": "ClearURLs is disabled on $1",
+        "description": "This string is used to show that ClearURLs is disabled on the current site."
+    },
+    "popup_html_site_unavailable": {
+        "message": "This page does not have a normal site hostname.",
+        "description": "This string is used when the current tab does not expose a normal site hostname."
+    },
     "popup_html_report_button": {
         "message": "Report current URL",
         "description": "Note: Currently not used."

--- a/clearurls.js
+++ b/clearurls.js
@@ -606,6 +606,10 @@ function start() {
      * @return {Array}                  redirectUrl or none
      */
     function clearUrl(request) {
+        if (isURLDisabled(getRequestContextURL(request))) {
+            return {};
+        }
+
         const URLbeforeReplaceCount = countFields(request.url);
 
         //Add Fields form Request to global url counter

--- a/core_js/historyListener.js
+++ b/core_js/historyListener.js
@@ -37,7 +37,7 @@ function historyListenerStart() {
 * which is associated with the new history entry created by replaceState()
 */
 function historyCleaner(details) {
-    if(storage.globalStatus) {
+    if(storage.globalStatus && !isURLDisabled(details.url)) {
         const urlBefore = details.url;
         const urlAfter = pureCleaning(details.url);
 

--- a/core_js/popup.js
+++ b/core_js/popup.js
@@ -31,6 +31,10 @@ var hashStatus;
 var loggingStatus;
 var statisticsStatus;
 var currentURL;
+var disabledDomains = [];
+var currentHostname = "";
+var siteSwitchButton = document.getElementById('siteSwitchButton');
+var siteStatus = document.getElementById('siteStatus');
 
 /**
 * Initialize the UI.
@@ -44,6 +48,7 @@ function init()
     setSwitchButton("statistics", "statisticsStatus");
     setHashStatus();
     changeStatistics();
+    updateSiteSection();
 }
 
 /**
@@ -180,6 +185,78 @@ function resetGlobalCounter(){
     changeStatistics();
 }
 
+function updateSiteSection() {
+    if (!siteSwitchButton || !siteStatus) {
+        return;
+    }
+
+    const siteDisabled = disabledDomains.includes(currentHostname);
+
+    if (!currentHostname) {
+        siteStatus.textContent = translate('popup_html_site_unavailable');
+        siteSwitchButton.disabled = true;
+        siteSwitchButton.textContent = translate('popup_html_site_disable');
+        siteSwitchButton.removeAttribute('title');
+        return;
+    }
+
+    siteSwitchButton.disabled = false;
+
+    if (siteDisabled) {
+        siteStatus.textContent = translate('popup_html_site_disabled', currentHostname);
+        siteSwitchButton.textContent = translate('popup_html_site_enable');
+        siteSwitchButton.setAttribute('title', translate('popup_html_site_enable_title'));
+    } else {
+        siteStatus.textContent = translate('popup_html_site_enabled', currentHostname);
+        siteSwitchButton.textContent = translate('popup_html_site_disable');
+        siteSwitchButton.setAttribute('title', translate('popup_html_site_disable_title'));
+    }
+}
+
+function toggleCurrentSite() {
+    if (!currentHostname) {
+        return;
+    }
+
+    const siteDisabled = disabledDomains.includes(currentHostname);
+
+    browser.runtime.sendMessage({
+        function: "setDisabledDomain",
+        params: [currentHostname, !siteDisabled]
+    }).then(() => {
+        if (siteDisabled) {
+            disabledDomains = disabledDomains.filter((domain) => domain !== currentHostname);
+        } else {
+            disabledDomains.push(currentHostname);
+            disabledDomains.sort();
+        }
+
+        updateSiteSection();
+
+        return browser.runtime.sendMessage({
+            function: "saveOnExit",
+            params: []
+        });
+    }).catch(handleError);
+}
+
+function loadCurrentTab() {
+    return browser.tabs.query({
+        active: true,
+        currentWindow: true
+    }).then((tabs) => {
+        const activeTab = tabs[0];
+
+        currentURL = activeTab && activeTab.url ? activeTab.url : "";
+
+        try {
+            currentHostname = currentURL ? new URL(currentURL).hostname.toLowerCase() : "";
+        } catch (error) {
+            currentHostname = "";
+        }
+    });
+}
+
 (function() {
     loadData("cleanedCounter")
         .then(() => loadData("totalCounter"))
@@ -188,7 +265,8 @@ function resetGlobalCounter(){
         .then(() => loadData("hashStatus"))
         .then(() => loadData("loggingStatus"))
         .then(() => loadData("statisticsStatus"))
-        .then(() => loadData("getCurrentURL", "currentURL"))
+        .then(() => loadData("disabledDomains"))
+        .then(() => loadCurrentTab())
         .then(() => {
             init();
             document.getElementById('reset_counter_btn').onclick = resetGlobalCounter;
@@ -196,6 +274,7 @@ function resetGlobalCounter(){
             changeSwitchButton("tabcounter", "badgedStatus");
             changeSwitchButton("logging", "loggingStatus");
             changeSwitchButton("statistics", "statisticsStatus");
+            siteSwitchButton.onclick = toggleCurrentSite;
             document.getElementById('loggingPage').href = browser.runtime.getURL('./html/log.html');
             document.getElementById('settings').href = browser.runtime.getURL('./html/settings.html');
             document.getElementById('cleaning_tools').href = browser.runtime.getURL('./html/cleaningTool.html');
@@ -209,6 +288,7 @@ function resetGlobalCounter(){
 function setText()
 {
     injectText('loggingPage','popup_html_log_head');
+    injectText('siteHead', 'popup_html_site_head');
     injectText('reset_counter_btn','popup_html_statistics_reset_button');
     injectText('rules_status_head','popup_html_rules_status_head');
     injectText('statistics_percentage','popup_html_statistics_percentage');
@@ -221,6 +301,7 @@ function setText()
     injectText('configs_head','popup_html_configs_head');
     injectText('configs_switch_statistics','configs_switch_statistics');
     document.getElementById('donate').title = translate('donate_button');
+    updateSiteSection();
 }
 
 /**
@@ -271,9 +352,9 @@ async function loadData(name, varName=name) {
 *
 * @param {string} string Name of the attribute used for localization
 */
-function translate(string)
+function translate(string, ...placeholders)
 {
-    return browser.i18n.getMessage(string);
+    return browser.i18n.getMessage(string, placeholders);
 }
 
 function handleError(error) {

--- a/core_js/popup.js
+++ b/core_js/popup.js
@@ -228,7 +228,7 @@ function toggleCurrentSite() {
             disabledDomains = disabledDomains.filter((domain) => domain !== currentHostname);
         } else {
             disabledDomains.push(currentHostname);
-            disabledDomains.sort();
+            disabledDomains.sort((left, right) => left.localeCompare(right));
         }
 
         updateSiteSection();

--- a/core_js/storage.js
+++ b/core_js/storage.js
@@ -116,6 +116,9 @@ function genesis() {
         //Set correct icon on startup
         changeIcon();
 
+        // Cache active and open tab URLs for per-site controls and filtering
+        initializeTabURLs();
+
         // Start the context_menu
         contextMenuStart();
 
@@ -162,6 +165,9 @@ function setData(key, value) {
             break;
         case "types":
             storage[key] = value.split(',');
+            break;
+        case "disabledDomains":
+            storage[key] = Array.isArray(value) ? value : value.split(',').filter(Boolean);
             break;
         case "logLimit":
             storage[key] = Math.max(0, Number(value));
@@ -224,6 +230,7 @@ function initSettings() {
     storage.domainBlocking = true;
     storage.pingBlocking = true;
     storage.eTagFiltering = false;
+    storage.disabledDomains = [];
     storage.watchDogErrorCount = 0;
 
     if (getBrowser() === "Firefox") {

--- a/core_js/tools.js
+++ b/core_js/tools.js
@@ -255,7 +255,7 @@ function setDisabledDomain(hostname, disabled = true) {
         domains.delete(normalizedHostname);
     }
 
-    storage.disabledDomains = Array.from(domains).sort();
+    storage.disabledDomains = Array.from(domains).sort((left, right) => left.localeCompare(right));
 
     return true;
 }

--- a/core_js/tools.js
+++ b/core_js/tools.js
@@ -23,6 +23,8 @@
 
 // Needed by the sha256 method
 const enc = new TextEncoder();
+let currentURL = "";
+let tabURLs = {};
 
 // Max amount of log entries to prevent performance issues
 const logThreshold = 5000;
@@ -222,6 +224,126 @@ function getCurrentURL() {
     return currentURL;
 }
 
+function normalizeHostname(hostname) {
+    return (hostname || "").trim().toLowerCase();
+}
+
+function extractHostnameFromURL(url) {
+    try {
+        return normalizeHostname(new URL(url).hostname);
+    } catch (error) {
+        return "";
+    }
+}
+
+function getDisabledDomains() {
+    return storage.disabledDomains || [];
+}
+
+function setDisabledDomain(hostname, disabled = true) {
+    const normalizedHostname = normalizeHostname(hostname);
+
+    if (!normalizedHostname) {
+        return false;
+    }
+
+    const domains = new Set(getDisabledDomains());
+
+    if (disabled) {
+        domains.add(normalizedHostname);
+    } else {
+        domains.delete(normalizedHostname);
+    }
+
+    storage.disabledDomains = Array.from(domains).sort();
+
+    return true;
+}
+
+function isDomainDisabled(hostname) {
+    const normalizedHostname = normalizeHostname(hostname);
+
+    if (!normalizedHostname) {
+        return false;
+    }
+
+    return getDisabledDomains().includes(normalizedHostname);
+}
+
+function isURLDisabled(url) {
+    return isDomainDisabled(extractHostnameFromURL(url));
+}
+
+function setTabURL(tabId, url) {
+    if (typeof tabId !== "number" || tabId < 0 || !url) {
+        return;
+    }
+
+    tabURLs[tabId] = url;
+}
+
+function getTabURL(tabId) {
+    if (typeof tabId !== "number" || tabId < 0) {
+        return "";
+    }
+
+    return tabURLs[tabId] || "";
+}
+
+function removeTabURL(tabId) {
+    delete tabURLs[tabId];
+}
+
+function refreshCurrentURL() {
+    browser.tabs.query({
+        active: true,
+        currentWindow: true
+    }).then((tabs) => {
+        if (tabs.length > 0) {
+            currentURL = tabs[0].url || "";
+            setTabURL(tabs[0].id, currentURL);
+        } else {
+            currentURL = "";
+        }
+    }).catch(handleError);
+}
+
+function getRequestContextURL(request) {
+    if (request.type === "main_frame") {
+        return request.url;
+    }
+
+    const tabURL = getTabURL(request.tabId);
+
+    if (tabURL) {
+        return tabURL;
+    }
+
+    if (request.documentUrl) {
+        return request.documentUrl;
+    }
+
+    if (request.originUrl) {
+        return request.originUrl;
+    }
+
+    if (request.initiator) {
+        return request.initiator;
+    }
+
+    return "";
+}
+
+function initializeTabURLs() {
+    browser.tabs.query({}).then((tabs) => {
+        tabs.forEach((tab) => {
+            setTabURL(tab.id, tab.url);
+        });
+    }).catch(handleError);
+
+    refreshCurrentURL();
+}
+
 /**
  * Check for browser.
  */
@@ -232,6 +354,29 @@ function getBrowser() {
         return "Chrome";
     }
 }
+
+browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (changeInfo.url) {
+        setTabURL(tabId, changeInfo.url);
+    } else if (tab && tab.url) {
+        setTabURL(tabId, tab.url);
+    }
+
+    if (tab && tab.active) {
+        currentURL = tab.url || changeInfo.url || currentURL;
+    }
+});
+
+browser.tabs.onActivated.addListener((activeInfo) => {
+    browser.tabs.get(activeInfo.tabId).then((tab) => {
+        currentURL = tab.url || "";
+        setTabURL(tab.id, currentURL);
+    }).catch(handleError);
+});
+
+browser.tabs.onRemoved.addListener((tabId) => {
+    removeTabURL(tabId);
+});
 
 /**
  * Decodes an URL, also one that is encoded multiple times.

--- a/html/popup.html
+++ b/html/popup.html
@@ -90,6 +90,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </div>
             </div>
 
+            <div class="row" id="site_section">
+                <div class="col-sm-4 offset-sm-4">
+                    <h5><b id="siteHead"></b></h5>
+                    <p class="small text-muted" id="siteStatus"></p>
+                    <div class="text-center">
+                        <button type="button" id="siteSwitchButton"
+                        class="btn btn-warning btn-sm btn-block text-wrap"></button>
+                    </div>
+                    <div class="clearfix"></div>
+                    <br />
+                </div>
+            </div>
+
             <div class="row" id="statistic_section">
                 <div class="col-sm-4 offset-sm-4">
                     <h5><b id="statistics_head"></b></h5>


### PR DESCRIPTION
## Summary

This PR introduces a per-site disable control, allowing users to quickly turn ClearURLs off for the current site when it breaks a workflow. 

It adds a popup action to toggle ClearURLs on the active site, persists the disabled hostnames in extension storage, and bypasses URL cleaning for requests and history updates originating from those sites.

## Problem

Currently, ClearURLs can only be toggled globally. When a specific site breaks, users have no fast escape hatch other than disabling the entire add-on and waiting for a upstream fix. This makes site-specific regressions much more disruptive than necessary.

## Changes

- **Storage & State:** Added a persisted `disabledDomains` list in extension storage.
- **Background Script:** Added shared hostname helpers and tab URL tracking.
- **Popup UI:** Added a new `Site` section featuring:
  - Current site status.
  - A toggle button (`Disable on this site` / `Enable on this site`).
- **Logic Bypasses:** - Bypasses `webRequest` URL cleaning when the current site is disabled.
  - Bypasses history API cleaning for disabled sites.
- **i18n:** Added English localization strings for the new popup UI elements.

## Behavior

- Disabling a site strictly affects that specific site's hostname.
- The add-on remains active globally for all other sites.
- Users can easily re-enable the site using the same popup control.

## Notes

- This PR is intentionally scoped to the per-site disable feature to address issue #509.
- It does **not** add an allowlist-only mode or a “clean only on selected sites” feature, as those would require separate product and implementation design.